### PR TITLE
Allow bulk_update on failed jobs with ActiveRecord backend

### DIFF
--- a/lib/delayed/backend/active_record.rb
+++ b/lib/delayed/backend/active_record.rb
@@ -139,7 +139,7 @@ module Delayed
         def self.bulk_update(action, opts)
           raise("Can't #{action.to_s} failed jobs") if opts[:flavor].to_s == 'failed' && action.to_s != 'destroy'
           scope = if opts[:ids]
-            if opts[:flavor].present? && opts[:flavor] == 'failed'
+            if opts[:flavor] == 'failed'
               Delayed::Job::Failed.where(:id => opts[:ids])
             else
               self.where(:id => opts[:ids])

--- a/lib/delayed/backend/active_record.rb
+++ b/lib/delayed/backend/active_record.rb
@@ -137,11 +137,16 @@ module Delayed
         # to specify the jobs to act on, either pass opts[:ids] = [list of job ids]
         # or opts[:flavor] = <some flavor> to perform on all jobs of that flavor
         def self.bulk_update(action, opts)
-          scope = if opts[:flavor]
-            raise("Can't bulk update failed jobs") if opts[:flavor].to_s == 'failed'
+          raise("Can't #{action.to_s} failed jobs") if opts[:flavor].to_s == 'failed' && action.to_s != 'destroy'
+          scope = if opts[:ids]
+            if opts[:flavor].present? && opts[:flavor] == 'failed'
+              Delayed::Job::Failed.where(:id => opts[:ids])
+            else
+              self.where(:id => opts[:ids])
+            end
+          elsif opts[:flavor]
+
             self.scope_for_flavor(opts[:flavor], opts[:query])
-          elsif opts[:ids]
-            self.where(:id => opts[:ids])
           end
 
           return 0 unless scope

--- a/spec/active_record_job_spec.rb
+++ b/spec/active_record_job_spec.rb
@@ -85,7 +85,7 @@ describe 'Delayed::Backed::ActiveRecord::Job' do
       expect { Delayed::Job.bulk_update('hold', :flavor => @flavor, :query => @query) }.to raise_error
     end
 
-    it "should raise error unholding holding failed jobs" do
+    it "should raise error holding or unholding failed jobs" do
       expect { Delayed::Job.bulk_update('unhold', :flavor => @flavor, :query => @query) }.to raise_error
     end
 

--- a/spec/active_record_job_spec.rb
+++ b/spec/active_record_job_spec.rb
@@ -75,7 +75,7 @@ describe 'Delayed::Backed::ActiveRecord::Job' do
       @affected_jobs = []
       @ignored_jobs = []
       Timecop.freeze(5.minutes.ago) do
-        3.times { @affected_jobs << create_job.tap { |j| j.fail! } }
+        5.times { @affected_jobs << create_job.tap { |j| j.fail! } }
         @ignored_jobs << create_job(:run_at => 2.hours.from_now)
         @ignored_jobs << create_job(:queue => 'q2')
       end
@@ -89,7 +89,12 @@ describe 'Delayed::Backed::ActiveRecord::Job' do
       expect { Delayed::Job.bulk_update('unhold', :flavor => @flavor, :query => @query) }.to raise_error
     end
 
-    it "should delete failed jobs" do
+    it "should delete failed jobs by id" do
+      target_ids = Delayed::Job::Failed.all[0..2].map { |j| j.id }
+      Delayed::Job.bulk_update('destroy', :ids => target_ids, :flavor => @flavor, :query => @query).should == target_ids.length
+    end
+
+    it "should delete all failed jobs" do
       Delayed::Job.bulk_update('destroy', :flavor => @flavor, :query => @query).should == @affected_jobs.size
       @affected_jobs.map { |j| Delayed::Job.find(j.id) rescue nil }.compact.should be_blank
       @ignored_jobs.map { |j| Delayed::Job.find(j.id) rescue nil }.compact.size.should == @ignored_jobs.size


### PR DESCRIPTION
This patch enables some bulk_update operations on Delayed::Job::Failed
objects (e.g. it only works with the ActiveRecord backend).
Specifically, the following are now enabled:

- destroy failed jobs by IDs
- destroy failed jobs by flavor

Hold and un-hold are not supported on failed jobs, since it doesn't make
sense to try those operations on failed jobs. Doing so will raise a
RuntimeException.

A signed Instructure Contributor License Agreement is on file under my employer, Simon Fraser University. 