### PR TITLE
Add support to silence active record logs for the job queue polling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ gemfile:
   - spec/gemfiles/42.gemfile
 rvm:
   - 1.9.3
-  - 2.1.4
+  - 2.1.6
 matrix:
   exclude:
 script: bundle exec rake spec

--- a/lib/delayed/version.rb
+++ b/lib/delayed/version.rb
@@ -1,3 +1,3 @@
 module Delayed
-  VERSION = "0.10.0"
+  VERSION = "0.10.1"
 end


### PR DESCRIPTION
Dear Instructure maintainer, please accept my humble pull request for this awesome gem.

We're running a lot of stuff through docker-compose and job polling SQL statements in the console output drive us mad. This is a way to make them configurable via an environment variable.

Please let me know if you'd like me to add documentation for it, or change this setting in any way.