### PR TITLE
Restore ability to delete failed jobs

### DIFF
--- a/lib/delayed/backend/active_record.rb
+++ b/lib/delayed/backend/active_record.rb
@@ -167,7 +167,7 @@ module Delayed
             scope = scope.where(locked_by: ON_HOLD_LOCKED_BY)
             scope.update_all(["locked_by = NULL, locked_at = NULL, attempts = 0, run_at = (CASE WHEN run_at > ? THEN run_at ELSE ? END), failed_at = NULL", now, now])
           when 'destroy'
-            scope = scope.where("locked_by IS NULL OR locked_by=?", ON_HOLD_LOCKED_BY)
+            scope = scope.where("locked_by IS NULL OR locked_by=?", ON_HOLD_LOCKED_BY) unless opts[:flavor] == 'failed'
             scope.delete_all
           end
         end


### PR DESCRIPTION
Changes I made in #2 (d201057) to allow bulk_update to delete failed jobs were affected by a826072 (@ccutrer: don't allow deletion/holding of locked jobs). When a job fails, it is already locked by the worker that attempted to process the job prior to its failure.

The tests I wrote for d201057 didn't lock the test jobs prior to failing them, so the tests still passed after a826072.

This commit:
 - modifies `bulk_update` to bypass the scope.where call for failed jobs
 - modifies the 'bulk_update failed jobs' tests to lock the jobs prior to failing them. This way, they fail with the change made in a826072, and pass after my mod.